### PR TITLE
Fix class name in MainScene

### DIFF
--- a/Core/MainScene.cs
+++ b/Core/MainScene.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 namespace _project.Scripts.Core
 {
-    public class MaineScene : MonoBehaviour
+    public class MainScene : MonoBehaviour
     {
         [SerializeField] private float startingAudioLevel;
 


### PR DESCRIPTION
## Summary
- fix a typo in `MainScene.cs`
------
https://chatgpt.com/codex/tasks/task_e_685f06a7abfc832c86e10d842273be9f