### PR TITLE
Introduce Discovery Mode with treatment tracking

### DIFF
--- a/Card Core/DeckManager.cs
+++ b/Card Core/DeckManager.cs
@@ -237,6 +237,7 @@ namespace _project.Scripts.Card_Core
         private readonly CardHand _afflictionHand = new("Afflictions Hand", AfflictionsDeck, PrototypeAfflictionsDeck);
         private readonly CardHand _plantHand = new("Plants Hand", PlantDeck, PrototypePlantsDeck);
         private readonly List<ICard> _actionHand = new();
+        private readonly Dictionary<ICard, int> _activeLocationCardPlacements = new();
         private bool _usingTutorialActionDeck;
 
         public List<PlantHolder> plantLocations = new();
@@ -1470,6 +1471,13 @@ namespace _project.Scripts.Card_Core
                 return;
             }
 
+            if (_actionDiscardPile.Contains(card))
+            {
+                if (debug)
+                    Debug.LogWarning($"[DeckManager] Attempted to discard card '{card?.Name}', but it is already in the discard pile.");
+                return;
+            }
+
             _actionDiscardPile.Add(card);
         }
 
@@ -1510,6 +1518,37 @@ namespace _project.Scripts.Card_Core
         public void AddCardToHand(ICard card)
         {
             _actionHand.Add(card);
+        }
+
+        internal void RemoveCardFromHandOnly(ICard card)
+        {
+            if (card == null) return;
+            _actionHand.Remove(card);
+        }
+
+        internal void RegisterLocationCardPlacement(ICard card)
+        {
+            if (card == null) return;
+            if (_activeLocationCardPlacements.TryGetValue(card, out var count))
+                _activeLocationCardPlacements[card] = count + 1;
+            else
+                _activeLocationCardPlacements[card] = 1;
+        }
+
+        internal void UnregisterLocationCardPlacement(ICard card)
+        {
+            if (card == null) return;
+            if (!_activeLocationCardPlacements.TryGetValue(card, out var count)) return;
+
+            count--;
+            if (count > 0)
+            {
+                _activeLocationCardPlacements[card] = count;
+                return;
+            }
+
+            _activeLocationCardPlacements.Remove(card);
+            DiscardActionCard(card, true);
         }
 
         /// <summary>

--- a/Classes/PlantAfflictions.cs
+++ b/Classes/PlantAfflictions.cs
@@ -89,6 +89,11 @@ namespace _project.Scripts.Classes
 
                 foreach (var item in afflictions)
                 {
+                    // For incompatible treatments, TreatWith exits before reaching
+                    // GetRelationalEfficacy. Record the attempt for Discovery Mode.
+                    if (!item.CanBeTreatedBy(this))
+                        CardGameMaster.Instance?.treatmentEfficacyHandler?.GetRelationalEfficacy(item, this);
+
                     var success = item.TreatWith(this, plant);
                     AnalyticsFunctions.RecordTreatment(plant.name, item.Name, Name, success);
 

--- a/Data/UserQualitySettings.cs
+++ b/Data/UserQualitySettings.cs
@@ -1,4 +1,6 @@
 using System;
+using _project.Scripts.Card_Core;
+using _project.Scripts.Handlers;
 using _project.Scripts.UI;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -8,20 +10,26 @@ namespace _project.Scripts.Data
     public class UserQualitySettings : MonoBehaviour
     {
         private const string QualityLevelPrefKey = "QualityLevel";
+        public const string DiscoveryModePrefKey = "DiscoveryModeEnabled";
         public UIDocument uiDocument;
 
         [SerializeField] private MenuManager menuManager;
-        private DropdownField _displayModeDropdown;
-
-        private Button _doneButton;
-        private RadioButton _highQualityRadioButton;
-        private RadioButton _lowQualityRadioButton;
-        private RadioButton _mediumQualityRadioButton;
-        private RadioButton _mobileQualityRadioButton;
-        private RadioButtonGroup _qualityRadioButtonGroup;
-        private DropdownField _resolutionDropdown;
         private VisualElement _rootElement;
         private UIDocument _settingsUIDocument;
+        private DropdownField _displayModeDropdown;
+        
+        private Button _doneButton;
+        private Button _clearDiscoveriesButton;
+        
+        private RadioButtonGroup _qualityRadioButtonGroup;
+        private RadioButton _highQualityRadioButton;
+        private RadioButton _mediumQualityRadioButton;
+        private RadioButton _lowQualityRadioButton;
+        private RadioButton _mobileQualityRadioButton;
+        
+        private DropdownField _resolutionDropdown;
+        private DropdownField _discoveryModeDropdown;
+        
         private Slider _volumeSlider;
 
         private void OnEnable()
@@ -39,9 +47,12 @@ namespace _project.Scripts.Data
             _volumeSlider = _rootElement.Q<Slider>("VolumeSlider");
             _resolutionDropdown = _rootElement.Q<DropdownField>("ResolutionDropDown");
             _displayModeDropdown = _rootElement.Q<DropdownField>("DisplayModeDropDown");
+            _discoveryModeDropdown = _rootElement.Q<DropdownField>("DiscoveryModeDropDown");
+            _clearDiscoveriesButton = _rootElement.Q<Button>("ClearDiscoveriesButton");
 
             // Register a callback for the done button to set the quality and hide the settings document
             _doneButton.clicked += OnDoneButtonClicked;
+            _clearDiscoveriesButton.clicked += OnClearDiscoveriesButtonClicked;
 
             // Check to see if it's all there
             if (_qualityRadioButtonGroup == null) Debug.LogError("No RadioButtonGroup found");
@@ -49,6 +60,7 @@ namespace _project.Scripts.Data
             if (_volumeSlider == null) Debug.LogError("No VolumeSlider found");
             if (_resolutionDropdown == null) Debug.LogError("No ResolutionDropdown found");
             if (_displayModeDropdown == null) Debug.LogError("No DisplayModeDropdown found");
+            if (_discoveryModeDropdown == null) Debug.LogError("No DiscoveryModeDropdown found");
 
             var radioButtons = new (string Name, object Value)[]
             {
@@ -134,6 +146,20 @@ namespace _project.Scripts.Data
 
                 _volumeSlider.RegisterValueChangedCallback(OnVolumeChanged);
             }
+            
+            // GameMode Settings
+
+            // Initialize discoveryMode dropdown to the current discovery mode and register callback
+            if (_discoveryModeDropdown != null)
+            {
+                _discoveryModeDropdown.RegisterValueChangedCallback(OnDiscoveryModeChanged);
+                SyncDiscoveryModeDropdown();
+            }
+        }
+
+        private void Start()
+        {
+            SyncDiscoveryModeDropdown();
         }
 
         private void OnDisable()
@@ -143,6 +169,7 @@ namespace _project.Scripts.Data
             _resolutionDropdown?.UnregisterValueChangedCallback(OnResolutionChanged);
             _qualityRadioButtonGroup?.UnregisterValueChangedCallback(OnQualityChanged);
             _volumeSlider?.UnregisterValueChangedCallback(OnVolumeChanged);
+            _discoveryModeDropdown?.UnregisterValueChangedCallback(OnDiscoveryModeChanged);
         }
 
         private static void SetVolume(float newVolume)
@@ -210,6 +237,11 @@ namespace _project.Scripts.Data
             menuManager.CloseSettingsMenu();
         }
 
+        private static void OnClearDiscoveriesButtonClicked()
+        {
+            CardGameMaster.Instance.treatmentEfficacyHandler.ClearDiscoveredCombinations();
+        }
+
         private static void OnDisplayModeChanged(ChangeEvent<string> evt)
         {
             SetDisplayMode(evt.newValue);
@@ -228,6 +260,38 @@ namespace _project.Scripts.Data
         private static void OnVolumeChanged(ChangeEvent<float> evt)
         {
             SetVolume(evt.newValue);
+        }
+
+        private void OnDiscoveryModeChanged(ChangeEvent<string> evt)
+        {
+            if (_discoveryModeDropdown == null || _discoveryModeDropdown.choices.Count == 0) return;
+
+            var discoveryModeEnabled = evt.newValue == _discoveryModeDropdown.choices[0];
+            PlayerPrefs.SetInt(DiscoveryModePrefKey, discoveryModeEnabled ? 1 : 0);
+            PlayerPrefs.Save();
+
+            var handler = ResolveTreatmentEfficacyHandler();
+            if (handler != null) handler.DiscoveryModeEnabled = discoveryModeEnabled;
+        }
+
+        private void SyncDiscoveryModeDropdown()
+        {
+            if (_discoveryModeDropdown == null || _discoveryModeDropdown.choices.Count == 0) return;
+
+            var handler = ResolveTreatmentEfficacyHandler();
+            var discoveryModeEnabled = handler != null
+                ? handler.DiscoveryModeEnabled
+                : PlayerPrefs.GetInt(DiscoveryModePrefKey, 1) == 1;
+
+            var index = discoveryModeEnabled ? 0 : Mathf.Min(1, _discoveryModeDropdown.choices.Count - 1);
+            _discoveryModeDropdown.SetValueWithoutNotify(_discoveryModeDropdown.choices[index]);
+        }
+
+        private static TreatmentEfficacyHandler ResolveTreatmentEfficacyHandler()
+        {
+            return CardGameMaster.Instance?.treatmentEfficacyHandler != null
+                ? CardGameMaster.Instance.treatmentEfficacyHandler
+                : FindFirstObjectByType<TreatmentEfficacyHandler>();
         }
     }
 }

--- a/Data/UserQualitySettings.cs
+++ b/Data/UserQualitySettings.cs
@@ -44,11 +44,11 @@ namespace _project.Scripts.Data
             _mediumQualityRadioButton = _qualityRadioButtonGroup.Q<RadioButton>("MediumQualityRadioButton");
             _highQualityRadioButton = _qualityRadioButtonGroup.Q<RadioButton>("HighQualityRadioButton");
             _doneButton = _rootElement.Q<Button>("DoneButton");
+            _clearDiscoveriesButton = _rootElement.Q<Button>("ClearDiscoveriesButton");
             _volumeSlider = _rootElement.Q<Slider>("VolumeSlider");
             _resolutionDropdown = _rootElement.Q<DropdownField>("ResolutionDropDown");
             _displayModeDropdown = _rootElement.Q<DropdownField>("DisplayModeDropDown");
             _discoveryModeDropdown = _rootElement.Q<DropdownField>("DiscoveryModeDropDown");
-            _clearDiscoveriesButton = _rootElement.Q<Button>("ClearDiscoveriesButton");
 
             // Register a callback for the done button to set the quality and hide the settings document
             _doneButton.clicked += OnDoneButtonClicked;
@@ -57,6 +57,7 @@ namespace _project.Scripts.Data
             // Check to see if it's all there
             if (_qualityRadioButtonGroup == null) Debug.LogError("No RadioButtonGroup found");
             if (_doneButton == null) Debug.LogError("No DoneButton found");
+            if (_clearDiscoveriesButton == null) Debug.LogError("No clearDiscoveriesButton found");
             if (_volumeSlider == null) Debug.LogError("No VolumeSlider found");
             if (_resolutionDropdown == null) Debug.LogError("No ResolutionDropdown found");
             if (_displayModeDropdown == null) Debug.LogError("No DisplayModeDropdown found");
@@ -165,6 +166,7 @@ namespace _project.Scripts.Data
         private void OnDisable()
         {
             _doneButton.clicked -= OnDoneButtonClicked;
+            _clearDiscoveriesButton.clicked -= OnClearDiscoveriesButtonClicked;
             _displayModeDropdown?.UnregisterValueChangedCallback(OnDisplayModeChanged);
             _resolutionDropdown?.UnregisterValueChangedCallback(OnResolutionChanged);
             _qualityRadioButtonGroup?.UnregisterValueChangedCallback(OnQualityChanged);
@@ -239,7 +241,8 @@ namespace _project.Scripts.Data
 
         private static void OnClearDiscoveriesButtonClicked()
         {
-            CardGameMaster.Instance.treatmentEfficacyHandler.ClearDiscoveredCombinations();
+            // Use a static method so this works from any scene (menu, gameplay, etc.)
+            TreatmentEfficacyHandler.ClearDiscoveryFile();
         }
 
         private static void OnDisplayModeChanged(ChangeEvent<string> evt)

--- a/Handlers/TreatmentEfficacyHandler.cs
+++ b/Handlers/TreatmentEfficacyHandler.cs
@@ -193,21 +193,38 @@ namespace _project.Scripts.Handlers
 
         private static void SaveDiscoveryState(HashSet<string> hashSet)
         {
-            var discoveryData = new DiscoveryData
+            try
             {
-                discoveredComboHash = hashSet.ToList()
-            };
-            var json = JsonUtility.ToJson(discoveryData);
-            File.WriteAllText($"{Application.persistentDataPath}/discoveryData.json", json);
+                var discoveryData = new DiscoveryData
+                {
+                    discoveredComboHash = hashSet.ToList()
+                };
+                var json = JsonUtility.ToJson(discoveryData);
+                File.WriteAllText($"{Application.persistentDataPath}/discoveryData.json", json);
+            }
+            catch (IOException ex)
+            {
+                Debug.LogError($"[TreatmentEfficacyHandler] Failed to save discovery state: {ex.Message}");
+            }
         }
 
         private static DiscoveryData LoadDiscoveryData()
         {
             if (!DiscoveryDataExists()) return new DiscoveryData();
-            var loadedData = File.ReadAllText($"{Application.persistentDataPath}/discoveryData.json");
-            return string.IsNullOrEmpty(loadedData)
-                ? new DiscoveryData()
-                : JsonUtility.FromJson<DiscoveryData>(loadedData);
+
+            try
+            {
+                var loadedData = File.ReadAllText($"{Application.persistentDataPath}/discoveryData.json");
+                return string.IsNullOrEmpty(loadedData)
+                    ? new DiscoveryData()
+                    : JsonUtility.FromJson<DiscoveryData>(loadedData);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning(
+                    $"[TreatmentEfficacyHandler] Failed to load discovery data (file may be corrupted): {ex.Message}. Returning empty data.");
+                return new DiscoveryData();
+            }
         }
 
         private static bool DiscoveryDataExists() => File.Exists($"{Application.persistentDataPath}/discoveryData.json");

--- a/Handlers/TreatmentEfficacyHandler.cs
+++ b/Handlers/TreatmentEfficacyHandler.cs
@@ -247,16 +247,23 @@ namespace _project.Scripts.Handlers
             set => discoveryModeEnabled = value;
         }
 
-        /// <summary>
-        ///     Clears all discovered combinations, resetting the player's progress in discovery mode.
-        /// </summary>
         public void ClearDiscoveredCombinations()
         {
             discoveredCombinations.Clear();
-            // rm discoveryDataFile
-            if (DiscoveryDataExists()) File.Delete($"{Application.persistentDataPath}/discoveryData.json");
-            Debug.Log(
-                "[TreatmentEfficacyHandler] All discoveries cleared. Player will need to rediscover all combinations.");
+            ClearDiscoveryFile();
+        }
+
+        public static void ClearDiscoveryFile()
+        {
+            if (DiscoveryDataExists())
+            {
+                File.Delete($"{Application.persistentDataPath}/discoveryData.json");
+                Debug.Log("[TreatmentEfficacyHandler] Discovery file deleted. All discoveries cleared.");
+            }
+            else
+            {
+                Debug.Log("[TreatmentEfficacyHandler] No discovery file to clear.");
+            }
         }
     }
 }

--- a/Handlers/TreatmentEfficacyHandler.cs
+++ b/Handlers/TreatmentEfficacyHandler.cs
@@ -106,7 +106,12 @@ namespace _project.Scripts.Handlers
             }
 
             // Return Early if incompatible
-            if (!affliction.CanBeTreatedBy(treatment)) return 0;
+            if (!affliction.CanBeTreatedBy(treatment))
+            {
+                if (countInteraction)
+                    MarkAsDiscovered(treatmentName, afflictionName, 0);
+                return 0;
+            }
 
             var baseEfficacy = Mathf.Clamp(treatment.Efficacy ?? DefaultEfficacy, 0, 100);
             if (!countInteraction) return baseEfficacy;

--- a/PlayModeTest/TreatmentEfficacyHandlerTests.cs
+++ b/PlayModeTest/TreatmentEfficacyHandlerTests.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Reflection;
 using _project.Scripts.Classes;
 using _project.Scripts.Core;
 using _project.Scripts.Handlers;
+using _project.Scripts.PlayModeTest.Utilities.Reflection;
 using NUnit.Framework;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -13,6 +16,118 @@ namespace _project.Scripts.PlayModeTest
 {
     public class TreatmentEfficacyHandlerTests
     {
+        private static int FindSeedMatchingRoll(Func<int, bool> predicate)
+        {
+            for (var seed = 0; seed < 10_000; seed++)
+            {
+                Random.InitState(seed);
+                var roll = Random.Range(0, 100);
+                if (!predicate(roll)) continue;
+                return seed;
+            }
+
+            Assert.Fail("Failed to find a deterministic seed for the requested predicate.");
+            return -1;
+        }
+
+        private class TestAffliction : PlantAfflictions.IAffliction
+        {
+            private readonly bool _canTreat;
+
+            public TestAffliction(string name, bool canTreat)
+            {
+                Name = name;
+                _canTreat = canTreat;
+            }
+
+            public string Name { get; }
+
+            public string Description => string.Empty;
+            public Color Color => Color.white;
+            public Shader Shader => null;
+            public List<PlantAfflictions.ITreatment> AcceptableTreatments { get; } = new();
+
+            public bool CanBeTreatedBy(PlantAfflictions.ITreatment treatment)
+            {
+                return _canTreat;
+            }
+
+            public bool TreatWith(PlantAfflictions.ITreatment treatment, PlantController plant)
+            {
+                return _canTreat;
+            }
+
+            public void TickDay(PlantController plant)
+            {
+            }
+
+            public PlantAfflictions.IAffliction Clone()
+            {
+                return new TestAffliction(Name, _canTreat);
+            }
+        }
+
+        private class TestTreatment : PlantAfflictions.ITreatment
+        {
+            public TestTreatment(string name, int? efficacy)
+            {
+                Name = name;
+                Efficacy = efficacy;
+            }
+
+            public string Name { get; }
+            public string Description => string.Empty;
+            public int? InfectCureValue { get; set; }
+            public int? EggCureValue { get; set; }
+            public int? Efficacy { get; set; }
+        }
+
+        #region Setup and Teardown
+
+        private const int LargeDatasetSize = 1000; // Stress test with 1000 combinations
+
+        [TearDown]
+        public void TearDown()
+        {
+            // Clean up test file
+            var testPath = GetTestFilePath();
+            if (File.Exists(testPath)) File.Delete(testPath);
+
+            // Clean up any lingering GameObjects from failed tests
+            var handlers = Object.FindObjectsOfType<TreatmentEfficacyHandler>();
+            foreach (var handler in handlers) Object.DestroyImmediate(handler.gameObject);
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private static string GetTestFilePath()
+        {
+            return $"{Application.persistentDataPath}/discoveryData.json";
+        }
+
+        private static void CreateValidDiscoveryFile(params string[] keys)
+        {
+            var data = new DiscoveryData { discoveredComboHash = keys.ToList() };
+            var json = JsonUtility.ToJson(data);
+            File.WriteAllText(GetTestFilePath(), json);
+        }
+
+        private static void CreateCorruptedFile()
+        {
+            File.WriteAllText(GetTestFilePath(), "{ invalid json }}}");
+        }
+
+        private static void CreateEmptyFile()
+        {
+            File.WriteAllText(GetTestFilePath(), string.Empty);
+        }
+
+        #endregion
+
+        #region Existing Tests
+
         [Test]
         public void GetRelationalEfficacy_ReturnsTreatmentEfficacyForNewCombination()
         {
@@ -283,70 +398,503 @@ namespace _project.Scripts.PlayModeTest
             Object.DestroyImmediate(handlerGo);
         }
 
-        private static int FindSeedMatchingRoll(Func<int, bool> predicate)
-        {
-            for (var seed = 0; seed < 10_000; seed++)
-            {
-                Random.InitState(seed);
-                var roll = Random.Range(0, 100);
-                if (!predicate(roll)) continue;
-                return seed;
-            }
+        #endregion
 
-            Assert.Fail("Failed to find a deterministic seed for the requested predicate.");
-            return -1;
+        #region Basic Save/Load Tests
+
+        [Test]
+        public void SaveDiscoveryState_CreatesFileWithValidJSON()
+        {
+            // Arrange
+            var combinations = new HashSet<string> { "Treatment1|Affliction1", "Treatment2|Affliction2" };
+
+            // Act
+            TreatmentEfficacyHandlerReflection.InvokeSaveDiscoveryState(combinations);
+
+            // Assert
+            Assert.IsTrue(File.Exists(GetTestFilePath()), "Discovery file should be created");
+
+            var fileContent = File.ReadAllText(GetTestFilePath());
+            Assert.IsFalse(string.IsNullOrEmpty(fileContent), "File should contain data");
+
+            var loadedData = JsonUtility.FromJson<DiscoveryData>(fileContent);
+            Assert.IsNotNull(loadedData, "JSON should be valid");
+            Assert.AreEqual(2, loadedData.discoveredComboHash.Count, "Should contain 2 combinations");
         }
 
-        private class TestAffliction : PlantAfflictions.IAffliction
+        [Test]
+        public void LoadDiscoveryData_RestoresDiscoveredCombinations()
         {
-            private readonly bool _canTreat;
+            // Arrange
+            CreateValidDiscoveryFile("Treatment1|Affliction1", "Treatment2|Affliction2");
 
-            public TestAffliction(string name, bool canTreat)
-            {
-                Name = name;
-                _canTreat = canTreat;
-            }
+            // Act
+            var loadedData = TreatmentEfficacyHandlerReflection.InvokeLoadDiscoveryData();
 
-            public string Name { get; }
-
-            public string Description => string.Empty;
-            public Color Color => Color.white;
-            public Shader Shader => null;
-            public List<PlantAfflictions.ITreatment> AcceptableTreatments { get; } = new();
-
-            public bool CanBeTreatedBy(PlantAfflictions.ITreatment treatment)
-            {
-                return _canTreat;
-            }
-
-            public bool TreatWith(PlantAfflictions.ITreatment treatment, PlantController plant)
-            {
-                return _canTreat;
-            }
-
-            public void TickDay(PlantController plant)
-            {
-            }
-
-            public PlantAfflictions.IAffliction Clone()
-            {
-                return new TestAffliction(Name, _canTreat);
-            }
+            // Assert
+            Assert.IsNotNull(loadedData, "Loaded data should not be null");
+            Assert.AreEqual(2, loadedData.discoveredComboHash.Count, "Should load 2 combinations");
+            Assert.IsTrue(loadedData.discoveredComboHash.Contains("Treatment1|Affliction1"));
+            Assert.IsTrue(loadedData.discoveredComboHash.Contains("Treatment2|Affliction2"));
         }
 
-        private class TestTreatment : PlantAfflictions.ITreatment
+        [Test]
+        public void SaveAndLoad_RoundTrip_PreservesData()
         {
-            public TestTreatment(string name, int? efficacy)
+            // Arrange
+            var handlerGo = new GameObject(nameof(TreatmentEfficacyHandler));
+            var handler = handlerGo.AddComponent<TreatmentEfficacyHandler>();
+
+            var originalCombinations = new HashSet<string>
             {
-                Name = name;
-                Efficacy = efficacy;
+                "Treatment1|Affliction1",
+                "Treatment2|Affliction2",
+                "Treatment3|Affliction3"
+            };
+
+            // Act - Save
+            TreatmentEfficacyHandlerReflection.SetDiscoveredCombinations(handler, originalCombinations);
+            TreatmentEfficacyHandlerReflection.InvokeSaveDiscoveryState(originalCombinations);
+
+            // Destroy handler and create new one to simulate reload
+            Object.DestroyImmediate(handlerGo);
+
+            // Act - Load
+            var loadedData = TreatmentEfficacyHandlerReflection.InvokeLoadDiscoveryData();
+            var loadedCombinations = new HashSet<string>(loadedData.discoveredComboHash);
+
+            // Assert
+            Assert.AreEqual(originalCombinations.Count, loadedCombinations.Count, "Count should match");
+            foreach (var combo in originalCombinations)
+                Assert.IsTrue(loadedCombinations.Contains(combo), $"Should contain {combo}");
+        }
+
+        [Test]
+        public void IsDiscovered_ReflectsSavedStateAfterReload()
+        {
+            // Arrange - Create and save discoveries
+            var handlerGo = new GameObject(nameof(TreatmentEfficacyHandler));
+            var handler = handlerGo.AddComponent<TreatmentEfficacyHandler>();
+            handler.DiscoveryModeEnabled = true;
+
+            var combinations = new HashSet<string> { "TreatmentA|AfflictionA" };
+            TreatmentEfficacyHandlerReflection.SetDiscoveredCombinations(handler, combinations);
+            TreatmentEfficacyHandlerReflection.InvokeSaveDiscoveryState(combinations);
+
+            Object.DestroyImmediate(handlerGo);
+
+            // Act - Create new handler (simulates reload)
+            var newHandlerGo = new GameObject(nameof(TreatmentEfficacyHandler));
+            var newHandler = newHandlerGo.AddComponent<TreatmentEfficacyHandler>();
+            newHandler.DiscoveryModeEnabled = true;
+
+            // Load data and populate the handler
+            var loadedData = TreatmentEfficacyHandlerReflection.InvokeLoadDiscoveryData();
+            var loadedCombinations = new HashSet<string>(loadedData.discoveredComboHash);
+            TreatmentEfficacyHandlerReflection.SetDiscoveredCombinations(newHandler, loadedCombinations);
+
+            // Assert
+            Assert.IsTrue(newHandler.IsDiscovered("TreatmentA", "AfflictionA"),
+                "Previously discovered combination should be marked as discovered");
+            Assert.IsFalse(newHandler.IsDiscovered("TreatmentB", "AfflictionB"),
+                "New combination should not be discovered");
+
+            Object.DestroyImmediate(newHandlerGo);
+        }
+
+        [Test]
+        public void SaveDiscoveryState_EmptyDiscoveries_CreatesValidFile()
+        {
+            // Arrange
+            var emptyCombinations = new HashSet<string>();
+
+            // Act
+            TreatmentEfficacyHandlerReflection.InvokeSaveDiscoveryState(emptyCombinations);
+
+            // Assert
+            Assert.IsTrue(File.Exists(GetTestFilePath()), "File should be created even for empty data");
+
+            var fileContent = File.ReadAllText(GetTestFilePath());
+            var loadedData = JsonUtility.FromJson<DiscoveryData>(fileContent);
+
+            Assert.IsNotNull(loadedData, "Should deserialize without error");
+            Assert.AreEqual(0, loadedData.discoveredComboHash.Count, "Should contain no combinations");
+        }
+
+        [Test]
+        public void LoadDiscoveryData_FileDoesNotExist_ReturnsEmptyData()
+        {
+            // Arrange - Ensure no file exists
+            if (File.Exists(GetTestFilePath())) File.Delete(GetTestFilePath());
+
+            // Act
+            var loadedData = TreatmentEfficacyHandlerReflection.InvokeLoadDiscoveryData();
+
+            // Assert
+            Assert.IsNotNull(loadedData, "Should return non-null data");
+            Assert.AreEqual(0, loadedData.discoveredComboHash.Count, "Should return empty list");
+        }
+
+        #endregion
+
+        #region Edge Case Tests
+
+        [Test]
+        public void LoadDiscoveryData_CorruptedJSON_HandlesGracefully()
+        {
+            // Arrange
+            CreateCorruptedFile();
+
+            // Act
+            var loadedData = TreatmentEfficacyHandlerReflection.InvokeLoadDiscoveryData();
+
+            // Assert - Should return empty data, not crash
+            Assert.IsNotNull(loadedData, "Should return non-null data even with corrupted file");
+            Assert.AreEqual(0, loadedData.discoveredComboHash.Count, "Should return empty list for corrupted data");
+        }
+
+        [Test]
+        public void LoadDiscoveryData_EmptyFile_ReturnsEmptyData()
+        {
+            // Arrange
+            CreateEmptyFile();
+
+            // Act
+            var loadedData = TreatmentEfficacyHandlerReflection.InvokeLoadDiscoveryData();
+
+            // Assert
+            Assert.IsNotNull(loadedData, "Should return non-null data");
+            Assert.AreEqual(0, loadedData.discoveredComboHash.Count, "Should return empty list for empty file");
+        }
+
+        [Test]
+        public void SaveDiscoveryState_LargeDataset_SuccessfullySerializes()
+        {
+            // Arrange - Create large dataset
+            var largeCombinations = new HashSet<string>();
+            for (var i = 0; i < LargeDatasetSize; i++) largeCombinations.Add($"Treatment{i}|Affliction{i}");
+
+            // Act
+            TreatmentEfficacyHandlerReflection.InvokeSaveDiscoveryState(largeCombinations);
+
+            // Assert
+            Assert.IsTrue(File.Exists(GetTestFilePath()), "File should be created");
+
+            var loadedData = TreatmentEfficacyHandlerReflection.InvokeLoadDiscoveryData();
+            Assert.AreEqual(LargeDatasetSize, loadedData.discoveredComboHash.Count,
+                $"All {LargeDatasetSize} combinations should be preserved");
+
+            // Verify a few samples
+            Assert.IsTrue(loadedData.discoveredComboHash.Contains("Treatment0|Affliction0"));
+            Assert.IsTrue(loadedData.discoveredComboHash.Contains("Treatment500|Affliction500"));
+            Assert.IsTrue(
+                loadedData.discoveredComboHash.Contains(
+                    $"Treatment{LargeDatasetSize - 1}|Affliction{LargeDatasetSize - 1}"));
+        }
+
+        [Test]
+        public void SaveDiscoveryState_SpecialCharactersInNames_SerializesCorrectly()
+        {
+            // Arrange - Test various special characters
+            var specialCombinations = new HashSet<string>
+            {
+                "Treatment \"Quotes\"|Affliction 'Apostrophes'",
+                "Treatment|With|Pipes|Affliction|Too",
+                "Treatment\nNewline|Affliction\tTab",
+                "Treatment $pecial!|Affliction #Char$"
+            };
+
+            // Act
+            TreatmentEfficacyHandlerReflection.InvokeSaveDiscoveryState(specialCombinations);
+
+            // Assert
+            var loadedData = TreatmentEfficacyHandlerReflection.InvokeLoadDiscoveryData();
+            var loadedCombinations = new HashSet<string>(loadedData.discoveredComboHash);
+
+            Assert.AreEqual(specialCombinations.Count, loadedCombinations.Count, "Count should match");
+            foreach (var combo in specialCombinations)
+                Assert.IsTrue(loadedCombinations.Contains(combo), $"Should preserve special characters in: {combo}");
+        }
+
+        [Test]
+        public void MakeDiscoveryKey_ConsistentFormat()
+        {
+            // Arrange
+            var treatmentName = "Test Treatment";
+            var afflictionName = "Test Affliction";
+
+            // Act
+            var key = TreatmentEfficacyHandlerReflection.InvokeMakeDiscoveryKey(treatmentName, afflictionName);
+
+            // Assert
+            Assert.AreEqual("Test Treatment|Test Affliction", key,
+                "Key should follow '{treatment}|{affliction}' format");
+
+            // Verify consistency
+            var key2 = TreatmentEfficacyHandlerReflection.InvokeMakeDiscoveryKey(treatmentName, afflictionName);
+            Assert.AreEqual(key, key2, "Same inputs should produce identical keys");
+        }
+
+        [Test]
+        public void LoadDiscoveryData_DuplicatesInFile_DeduplicatesInMemory()
+        {
+            // Arrange - Manually create file with duplicates
+            var duplicateData = new DiscoveryData
+            {
+                discoveredComboHash = new List<string>
+                {
+                    "Treatment1|Affliction1",
+                    "Treatment2|Affliction2",
+                    "Treatment1|Affliction1", // Duplicate
+                    "Treatment3|Affliction3",
+                    "Treatment2|Affliction2" // Duplicate
+                }
+            };
+            var json = JsonUtility.ToJson(duplicateData);
+            File.WriteAllText(GetTestFilePath(), json);
+
+            // Act
+            var loadedData = TreatmentEfficacyHandlerReflection.InvokeLoadDiscoveryData();
+            var uniqueCombinations = new HashSet<string>(loadedData.discoveredComboHash);
+
+            // Assert
+            Assert.AreEqual(5, loadedData.discoveredComboHash.Count,
+                "List should contain all entries including duplicates");
+            Assert.AreEqual(3, uniqueCombinations.Count, "HashSet should deduplicate to 3 unique entries");
+        }
+
+        #endregion
+
+        #region Integration Tests
+
+        [Test]
+        public void MarkAsDiscovered_NewCombination_TriggersSave()
+        {
+            // Arrange
+            var handlerGo = new GameObject(nameof(TreatmentEfficacyHandler));
+            var handler = handlerGo.AddComponent<TreatmentEfficacyHandler>();
+            handler.DiscoveryModeEnabled = true;
+
+            // Ensure file doesn't exist before test
+            if (File.Exists(GetTestFilePath())) File.Delete(GetTestFilePath());
+
+            // Act
+            TreatmentEfficacyHandlerReflection.InvokeMarkAsDiscovered(handler, "Treatment1", "Affliction1", 75);
+
+            // Assert
+            Assert.IsTrue(File.Exists(GetTestFilePath()), "File should be created after marking as discovered");
+
+            var loadedData = TreatmentEfficacyHandlerReflection.InvokeLoadDiscoveryData();
+            Assert.AreEqual(1, loadedData.discoveredComboHash.Count, "Should contain 1 combination");
+            Assert.IsTrue(loadedData.discoveredComboHash.Contains("Treatment1|Affliction1"));
+
+            Object.DestroyImmediate(handlerGo);
+        }
+
+        [Test]
+        public void MarkAsDiscovered_ExistingCombination_DoesNotTriggerSave()
+        {
+            // Arrange
+            var handlerGo = new GameObject(nameof(TreatmentEfficacyHandler));
+            var handler = handlerGo.AddComponent<TreatmentEfficacyHandler>();
+            handler.DiscoveryModeEnabled = true;
+
+            // Pre-populate with one discovery
+            var combinations = new HashSet<string> { "Treatment1|Affliction1" };
+            TreatmentEfficacyHandlerReflection.SetDiscoveredCombinations(handler, combinations);
+            TreatmentEfficacyHandlerReflection.InvokeSaveDiscoveryState(combinations);
+
+            // Read file content before re-marking
+            var originalFileContent = File.ReadAllText(GetTestFilePath());
+            var originalFileLength = new FileInfo(GetTestFilePath()).Length;
+
+            // Act - Mark the same combination again
+            TreatmentEfficacyHandlerReflection.InvokeMarkAsDiscovered(handler, "Treatment1", "Affliction1", 75);
+
+            // Assert - File should not be modified
+            var newFileContent = File.ReadAllText(GetTestFilePath());
+            var newFileLength = new FileInfo(GetTestFilePath()).Length;
+
+            Assert.AreEqual(originalFileContent, newFileContent,
+                "File content should not change when marking existing combination");
+            Assert.AreEqual(originalFileLength, newFileLength,
+                "File size should not change when marking existing combination");
+
+            Object.DestroyImmediate(handlerGo);
+        }
+
+        [Test]
+        public void IsDiscovered_DiscoveryModeDisabled_AlwaysReturnsTrue()
+        {
+            // Arrange
+            var handlerGo = new GameObject(nameof(TreatmentEfficacyHandler));
+            var handler = handlerGo.AddComponent<TreatmentEfficacyHandler>();
+            handler.DiscoveryModeEnabled = false;
+
+            // Empty discoveries - nothing discovered
+            var emptyCombinations = new HashSet<string>();
+            TreatmentEfficacyHandlerReflection.SetDiscoveredCombinations(handler, emptyCombinations);
+
+            // Act & Assert
+            Assert.IsTrue(handler.IsDiscovered("AnyTreatment", "AnyAffliction"),
+                "Should return true when discovery mode disabled");
+            Assert.IsTrue(handler.IsDiscovered("Another", "Combo"), "Should return true for any combination");
+
+            Object.DestroyImmediate(handlerGo);
+        }
+
+        [Test]
+        public void IsDiscovered_DiscoveryModeEnabled_RespectsActualState()
+        {
+            // Arrange
+            var handlerGo = new GameObject(nameof(TreatmentEfficacyHandler));
+            var handler = handlerGo.AddComponent<TreatmentEfficacyHandler>();
+            handler.DiscoveryModeEnabled = true;
+
+            var combinations = new HashSet<string> { "Known|Combo" };
+            TreatmentEfficacyHandlerReflection.SetDiscoveredCombinations(handler, combinations);
+
+            // Act & Assert
+            Assert.IsTrue(handler.IsDiscovered("Known", "Combo"), "Should return true for discovered combination");
+            Assert.IsFalse(handler.IsDiscovered("Unknown", "Combo"),
+                "Should return false for undiscovered combination");
+
+            Object.DestroyImmediate(handlerGo);
+        }
+
+        [Test]
+        public void ClearDiscoveredCombinations_DeletesFile()
+        {
+            // Arrange
+            var handlerGo = new GameObject(nameof(TreatmentEfficacyHandler));
+            var handler = handlerGo.AddComponent<TreatmentEfficacyHandler>();
+
+            var combinations = new HashSet<string> { "Treatment1|Affliction1", "Treatment2|Affliction2" };
+            TreatmentEfficacyHandlerReflection.SetDiscoveredCombinations(handler, combinations);
+            TreatmentEfficacyHandlerReflection.InvokeSaveDiscoveryState(combinations);
+
+            Assert.IsTrue(File.Exists(GetTestFilePath()), "File should exist before clearing");
+
+            // Act
+            handler.ClearDiscoveredCombinations();
+
+            // Assert
+            Assert.IsFalse(File.Exists(GetTestFilePath()), "File should be deleted after clearing");
+
+            var inMemoryCombinations = TreatmentEfficacyHandlerReflection.GetDiscoveredCombinations(handler);
+            Assert.AreEqual(0, inMemoryCombinations.Count, "In-memory HashSet should be empty");
+
+            Object.DestroyImmediate(handlerGo);
+        }
+
+        [Test]
+        public void GetRelationalEfficacy_DiscoveryIntegration_SavesOnFirstUse()
+        {
+            // Arrange
+            var handlerGo = new GameObject(nameof(TreatmentEfficacyHandler));
+            var handler = handlerGo.AddComponent<TreatmentEfficacyHandler>();
+            handler.DiscoveryModeEnabled = true;
+
+            var affliction = new TestAffliction("TestAffliction", true);
+            var treatment = new TestTreatment("TestTreatment", 80);
+
+            // Ensure file doesn't exist before test
+            if (File.Exists(GetTestFilePath())) File.Delete(GetTestFilePath());
+
+            // Act - Call with countInteraction=true (default)
+            var efficacy = handler.GetRelationalEfficacy(affliction, treatment);
+
+            // Assert
+            Assert.AreEqual(80, efficacy, "Should return correct efficacy");
+            Assert.IsTrue(File.Exists(GetTestFilePath()), "File should be created after first interaction");
+
+            var loadedData = TreatmentEfficacyHandlerReflection.InvokeLoadDiscoveryData();
+            Assert.AreEqual(1, loadedData.discoveredComboHash.Count, "Should save the discovery");
+            Assert.IsTrue(loadedData.discoveredComboHash.Contains("TestTreatment|TestAffliction"));
+
+            Object.DestroyImmediate(handlerGo);
+        }
+
+        #endregion
+
+        #region Data Integrity Tests
+
+        [Test]
+        public void SaveDiscoveryState_MultipleSaveCycles_NoDataCorruption()
+        {
+            // Arrange
+            var combinations = new HashSet<string>();
+
+            // Act - 5 save cycles, adding data each time
+            for (var cycle = 1; cycle <= 5; cycle++)
+            {
+                combinations.Add($"Treatment{cycle}|Affliction{cycle}");
+                TreatmentEfficacyHandlerReflection.InvokeSaveDiscoveryState(combinations);
+
+                // Verify after each save
+                var loadedData = TreatmentEfficacyHandlerReflection.InvokeLoadDiscoveryData();
+                Assert.AreEqual(cycle, loadedData.discoveredComboHash.Count,
+                    $"Should have {cycle} combinations after cycle {cycle}");
             }
 
-            public string Name { get; }
-            public string Description => string.Empty;
-            public int? InfectCureValue { get; set; }
-            public int? EggCureValue { get; set; }
-            public int? Efficacy { get; set; }
+            // Assert - Final verification
+            var finalData = TreatmentEfficacyHandlerReflection.InvokeLoadDiscoveryData();
+            var finalCombinations = new HashSet<string>(finalData.discoveredComboHash);
+
+            Assert.AreEqual(5, finalCombinations.Count, "Should have all 5 combinations");
+            for (var i = 1; i <= 5; i++)
+                Assert.IsTrue(finalCombinations.Contains($"Treatment{i}|Affliction{i}"),
+                    $"Should contain Treatment{i}|Affliction{i}");
         }
+
+        [Test]
+        public void HashSetToListToHashSet_PreservesUniqueness()
+        {
+            // Arrange
+            var originalHashSet = new HashSet<string>
+            {
+                "Treatment1|Affliction1",
+                "Treatment2|Affliction2",
+                "Treatment3|Affliction3"
+            };
+            var originalCount = originalHashSet.Count;
+
+            // Act - Convert HashSet -> List -> Save -> Load -> List -> HashSet
+            TreatmentEfficacyHandlerReflection.InvokeSaveDiscoveryState(originalHashSet);
+            var loadedData = TreatmentEfficacyHandlerReflection.InvokeLoadDiscoveryData();
+            var restoredHashSet = new HashSet<string>(loadedData.discoveredComboHash);
+
+            // Assert
+            Assert.AreEqual(originalCount, restoredHashSet.Count, "Count should remain the same through conversions");
+            foreach (var combo in originalHashSet)
+                Assert.IsTrue(restoredHashSet.Contains(combo), $"Should preserve {combo}");
+        }
+
+        [Test]
+        public void Awake_LoadsExistingData_BeforeFirstInteraction()
+        {
+            // Arrange - Pre-create discovery file
+            CreateValidDiscoveryFile("PreExisting|Combination");
+
+            // Act - Create handler (Awake automatically loads the file)
+            var handlerGo = new GameObject(nameof(TreatmentEfficacyHandler));
+            var handler = handlerGo.AddComponent<TreatmentEfficacyHandler>();
+
+            // Assert - Handler should have the pre-existing combination loaded by Awake()
+            var inMemoryCombinations = TreatmentEfficacyHandlerReflection.GetDiscoveredCombinations(handler);
+            Assert.AreEqual(1, inMemoryCombinations.Count, "Should load 1 combination from file during Awake()");
+            Assert.IsTrue(inMemoryCombinations.Contains("PreExisting|Combination"),
+                "Should contain the pre-existing combination");
+
+            // Verify IsDiscovered behavior (always returns true in both modes)
+            // - When discovery mode enabled: loaded combination should be marked discovered → true
+            // - When discovery mode disabled: IsDiscovered always returns true regardless
+            Assert.IsTrue(handler.IsDiscovered("PreExisting", "Combination"),
+                "IsDiscovered should return true for loaded combination (in both discovery modes)");
+
+            Object.DestroyImmediate(handlerGo);
+        }
+
+        #endregion
     }
 }

--- a/PlayModeTest/TreatmentEfficacyHandlerTests.cs
+++ b/PlayModeTest/TreatmentEfficacyHandlerTests.cs
@@ -788,6 +788,31 @@ namespace _project.Scripts.PlayModeTest
         }
 
         [Test]
+        public void ClearDiscoveryFile_Static_DeletesFileWithoutInstance()
+        {
+            // Arrange
+            CreateValidDiscoveryFile("Treatment1|Affliction1", "Treatment2|Affliction2");
+            Assert.IsTrue(File.Exists(GetTestFilePath()), "File should exist before clearing");
+
+            // Act - Call static method without needing a handler instance
+            TreatmentEfficacyHandler.ClearDiscoveryFile();
+
+            // Assert
+            Assert.IsFalse(File.Exists(GetTestFilePath()), "File should be deleted after static clear");
+        }
+
+        [Test]
+        public void ClearDiscoveryFile_Static_NoErrorWhenFileDoesNotExist()
+        {
+            // Arrange - Ensure no file exists
+            if (File.Exists(GetTestFilePath())) File.Delete(GetTestFilePath());
+
+            // Act & Assert - Should not throw exception
+            Assert.DoesNotThrow(() => TreatmentEfficacyHandler.ClearDiscoveryFile(),
+                "Should handle missing file gracefully");
+        }
+
+        [Test]
         public void GetRelationalEfficacy_DiscoveryIntegration_SavesOnFirstUse()
         {
             // Arrange

--- a/PlayModeTest/Utilities/Reflection/TreatmentEfficacyHandlerReflection.cs
+++ b/PlayModeTest/Utilities/Reflection/TreatmentEfficacyHandlerReflection.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using _project.Scripts.Handlers;
+
+namespace _project.Scripts.PlayModeTest.Utilities.Reflection
+{
+    /// <summary>
+    ///     Provides cached reflection access to TreatmentEfficacyHandler's private fields and methods.
+    ///     Use this instead of inline reflection to improve test performance and reduce code duplication.
+    /// </summary>
+    public static class TreatmentEfficacyHandlerReflection
+    {
+        private static readonly FieldInfo DiscoveredCombinationsField;
+        private static readonly MethodInfo MakeDiscoveryKeyMethod;
+        private static readonly MethodInfo SaveDiscoveryStateMethod;
+        private static readonly MethodInfo LoadDiscoveryDataMethod;
+        private static readonly MethodInfo DiscoveryDataExistsMethod;
+        private static readonly MethodInfo MarkAsDiscoveredMethod;
+
+        static TreatmentEfficacyHandlerReflection()
+        {
+            const BindingFlags instanceFlags = BindingFlags.NonPublic | BindingFlags.Instance;
+            const BindingFlags staticFlags = BindingFlags.NonPublic | BindingFlags.Static;
+
+            DiscoveredCombinationsField =
+                typeof(TreatmentEfficacyHandler).GetField("discoveredCombinations", instanceFlags);
+            MakeDiscoveryKeyMethod = typeof(TreatmentEfficacyHandler).GetMethod("MakeDiscoveryKey", staticFlags);
+            SaveDiscoveryStateMethod = typeof(TreatmentEfficacyHandler).GetMethod("SaveDiscoveryState", staticFlags);
+            LoadDiscoveryDataMethod = typeof(TreatmentEfficacyHandler).GetMethod("LoadDiscoveryData", staticFlags);
+            DiscoveryDataExistsMethod = typeof(TreatmentEfficacyHandler).GetMethod("DiscoveryDataExists", staticFlags);
+            MarkAsDiscoveredMethod = typeof(TreatmentEfficacyHandler).GetMethod("MarkAsDiscovered", instanceFlags);
+
+            // Validate all reflection targets were found
+            if (DiscoveredCombinationsField == null)
+                throw new InvalidOperationException(
+                    "TreatmentEfficacyHandler.discoveredCombinations field not found via reflection. Class may have been refactored.");
+            if (MakeDiscoveryKeyMethod == null)
+                throw new InvalidOperationException(
+                    "TreatmentEfficacyHandler.MakeDiscoveryKey method not found via reflection. Class may have been refactored.");
+            if (SaveDiscoveryStateMethod == null)
+                throw new InvalidOperationException(
+                    "TreatmentEfficacyHandler.SaveDiscoveryState method not found via reflection. Class may have been refactored.");
+            if (LoadDiscoveryDataMethod == null)
+                throw new InvalidOperationException(
+                    "TreatmentEfficacyHandler.LoadDiscoveryData method not found via reflection. Class may have been refactored.");
+            if (DiscoveryDataExistsMethod == null)
+                throw new InvalidOperationException(
+                    "TreatmentEfficacyHandler.DiscoveryDataExists method not found via reflection. Class may have been refactored.");
+            if (MarkAsDiscoveredMethod == null)
+                throw new InvalidOperationException(
+                    "TreatmentEfficacyHandler.MarkAsDiscovered method not found via reflection. Class may have been refactored.");
+        }
+
+        /// <summary>
+        ///     Gets the private discoveredCombinations HashSet from a TreatmentEfficacyHandler instance.
+        /// </summary>
+        public static HashSet<string> GetDiscoveredCombinations(TreatmentEfficacyHandler handler)
+        {
+            return DiscoveredCombinationsField?.GetValue(handler) as HashSet<string>;
+        }
+
+        /// <summary>
+        ///     Sets the private discoveredCombinations HashSet on a TreatmentEfficacyHandler instance.
+        /// </summary>
+        public static void SetDiscoveredCombinations(TreatmentEfficacyHandler handler, HashSet<string> combinations)
+        {
+            DiscoveredCombinationsField?.SetValue(handler, combinations);
+        }
+
+        /// <summary>
+        ///     Invokes the private static MakeDiscoveryKey method.
+        /// </summary>
+        public static string InvokeMakeDiscoveryKey(string treatmentName, string afflictionName)
+        {
+            return MakeDiscoveryKeyMethod?.Invoke(null, new object[] { treatmentName, afflictionName }) as string;
+        }
+
+        /// <summary>
+        ///     Invokes the private static SaveDiscoveryState method.
+        /// </summary>
+        public static void InvokeSaveDiscoveryState(HashSet<string> combinations)
+        {
+            SaveDiscoveryStateMethod?.Invoke(null, new object[] { combinations });
+        }
+
+        /// <summary>
+        ///     Invokes the private static LoadDiscoveryData method.
+        /// </summary>
+        public static DiscoveryData InvokeLoadDiscoveryData()
+        {
+            return LoadDiscoveryDataMethod?.Invoke(null, null) as DiscoveryData;
+        }
+
+        /// <summary>
+        ///     Invokes the private static DiscoveryDataExists method.
+        /// </summary>
+        public static bool InvokeDiscoveryDataExists()
+        {
+            return (bool)(DiscoveryDataExistsMethod?.Invoke(null, null) ?? false);
+        }
+
+        /// <summary>
+        ///     Invokes the private MarkAsDiscovered method.
+        /// </summary>
+        /// <param name="handler">Handler instance to invoke on</param>
+        /// <param name="treatmentName">Name of the treatment</param>
+        /// <param name="afflictionName">Name of the affliction</param>
+        /// <param name="existingEfficacy">Efficacy value (currently unused, reserved for future analytics)</param>
+        public static void InvokeMarkAsDiscovered(TreatmentEfficacyHandler handler, string treatmentName,
+            string afflictionName, int existingEfficacy)
+        {
+            MarkAsDiscoveredMethod?.Invoke(handler, new object[] { treatmentName, afflictionName, existingEfficacy });
+        }
+    }
+}

--- a/UI/UIInputManager.cs
+++ b/UI/UIInputManager.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace _project.Scripts.UI
 {
     /// <summary>
-    ///     Reason codes for forcing UIInput state, bypassing ownership model
+    ///     Reason codes for forcing UIInput state, bypassing the ownership model
     /// </summary>
     public enum ForcedStateReason
     {
@@ -83,7 +83,7 @@ namespace _project.Scripts.UI
         }
 
         /// <summary>
-        ///     Request to disable UIInput. Only succeeds if caller is the current owner or no owner is set.
+        ///     Request to disable UIInput. Only succeeds if the caller is the current owner or no owner is set.
         /// </summary>
         /// <param name="owner">The requesting system identifier</param>
         public static void RequestDisable(string owner)
@@ -97,7 +97,7 @@ namespace _project.Scripts.UI
                     return;
                 }
 
-                // Only allow to disable if this system is the current owner or if no owner is set
+                // Only allow disabling if this system is the current owner or if no owner is set
                 if (_currentOwner == owner || string.IsNullOrEmpty(_currentOwner))
                 {
                     CardGameMaster.Instance.uiInputModule.enabled = false;

--- a/docs/card-core-system.md
+++ b/docs/card-core-system.md
@@ -193,6 +193,11 @@ Manages card placement locations on plants, including card acceptance logic and 
 - Treatment efficacy display integration
 - Plant death handling
 
+**Location/Field Spell Behavior**:
+- Location cards leave the action hand on placement and are not manually retrievable
+- Field spells follow the same placement restrictions as location cards
+- Field spells only expire/return to discard when they also implement `ILocationCard`
+
 **Key Properties**:
 ```csharp
 public bool HoldingCard { get; }        // Whether holder has a card
@@ -204,6 +209,7 @@ public int PlacementTurn { get; }       // Turn when card was placed
 - **enableHoverPreview**: Toggle ghost preview on/off (default: true)
 - **previewAlpha**: Transparency of preview (default: 0.35, range 0-1)
 - Automatically shows preview when:
+  - Holder is hovered (mouse enter)
   - Holder is empty
   - Player has a card selected
   - Card is compatible with holder type
@@ -482,11 +488,7 @@ public void OnCardHolderClicked()
     {
         cardHolder.TakeSelectedCard();
     }
-    // Pick up card if holder has one
-    else if (cardHolder.HoldingCard)
-    {
-        cardHolder.OnPlacedCardClicked();
-    }
+    // Picking up placed cards is handled by the holder's internal click flow
 }
 ```
 
@@ -690,7 +692,7 @@ public class CardGameMaster : MonoBehaviour
 
 **Required Transforms**:
 - `actionCardParent`: Parent transform for action cards in hand
-- `plantLocations`: List of transforms where plants can be placed
+- `plantLocations`: List of `PlantHolder` instances where plants can be placed
 - `stickerPackParent`: Parent for sticker visuals
 
 **Configuration Values**:

--- a/docs/plant-location-card-slots-technical-design.md
+++ b/docs/plant-location-card-slots-technical-design.md
@@ -2,7 +2,16 @@
 
 ## Executive Summary
 
+**Note**: This document reflects an early design proposal and does not match the current implementation. For up-to-date behavior, see `Assets/_project/Scripts/docs/i-location-card-system.md` and `Assets/_project/Scripts/docs/card-core-system.md`.
+
 This document outlines the implementation plan for persistent plant location card slots in the Horticulture game. Each plant location will have a dedicated card slot that accepts special "Location Cards" providing ongoing effects to whatever plant occupies that location. These effects persist between rounds and are saved with the game state.
+
+## Current Implementation Notes
+
+- Location cards use `ILocationCard` with `EffectDuration`, `IsPermanent`, and turn-based effect methods.
+- Placement uses `PlacedCardHolder` + `SpotDataHolder`, not a `LocationCardSlot` component.
+- Location cards live in the action deck; there is no separate location deck or shop flow.
+- Placed location cards are not serialized; only per-plant tracking (e.g., `uLocationCards`) persists.
 
 ## Feature Requirements
 
@@ -18,7 +27,7 @@ This document outlines the implementation plan for persistent plant location car
 - Visual card slots at each plant location
 - Drag-and-drop interaction to place Location Cards
 - Clear visual indication of which location cards are active
-- Location Cards can be removed/replaced by players
+- Location Cards can be replaced by placing a new Location Card; manual removal is not supported
 - Tooltips showing active location effects
 
 ## Current Architecture Analysis


### PR DESCRIPTION
### Description

This pull request includes the following changes:

- **Refactor and Tests**:
  - Refactored `ClearDiscoveredCombinations` by introducing the static method `ClearDiscoveryFile` and updated button callback logic.
  - Added PlayMode tests for `ClearDiscoveryFile`.

- **Discovery Mode Implementation**:
  - Introduced "Discovery Mode" with PlayerPrefs integration for enabling/disabling.
  - Enhanced UI controls to support Discovery Mode, including a dropdown selection and clear discoveries button.
  - Updated `EfficacyDisplayHandler` to handle undiscovered combinations with "?" indicators and distinct coloring.
  - Added logic in `TreatmentEfficacyHandler` to track discovered treatment-affliction pairs.

- **Save/Load Functionality**:
  - Added `SaveDiscoveryState` and `LoadDiscoveryData` to persist discovered combinations across sessions.
  - Enhanced error handling during state saving/loading for large datasets and special characters.
  - Introduced `DiscoveryData` class for JSON serialization of data.
  - Enabled discovery data deletion when clearing combinations.

- **Location Card Enhancements**:
  - Introduced methods for managing location card lifecycle (`RegisterLocationCardPlacement`, `UnregisterLocationCardPlacement`) in `DeckManager`.
  - Improved location card placement logic, including handling of multi-plant field spells.
  - Updated lifecycle rules to handle automatic expiry and discard scenarios.

These changes enhance the system's usability, gameplay features, and data persistence while ensuring code clarity and easier future additions.
