### PR TITLE
Add Environment Upgrade System (BeeBox)

### DIFF
--- a/Card Core/CardGameMaster.cs
+++ b/Card Core/CardGameMaster.cs
@@ -34,6 +34,7 @@ namespace _project.Scripts.Card_Core
         public TurnController turnController;
         public ShopManager shopManager;
         public DeckOrganizerManager deckOrganizerManager;
+        public EnvironmentUpgradeManager environmentUpgradeManager;
         public SoundSystemMaster soundSystem;
         public CinematicDirector cinematicDirector;
         public PopUpController popUpController;

--- a/Card Core/EnvironmentUpgradeManager.cs
+++ b/Card Core/EnvironmentUpgradeManager.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using _project.Scripts.Classes;
+using UnityEngine;
+
+namespace _project.Scripts.Card_Core
+{
+    public class EnvironmentUpgradeManager : MonoBehaviour
+    {
+        [SerializeField] private List<Transform> upgradeSpawnPoints = new();
+
+        private readonly List<IEnvironmentUpgrade> _activeUpgrades = new();
+        private readonly Dictionary<IEnvironmentUpgrade, GameObject> _spawnedPrefabs = new();
+        private int _nextSpawnPointIndex;
+
+        public IReadOnlyList<IEnvironmentUpgrade> ActiveUpgrades => _activeUpgrades;
+
+        /// <summary>
+        ///     Purchases an upgrade, adds it to active upgrades, and spawns its prefab.
+        /// </summary>
+        public void PurchaseUpgrade(IEnvironmentUpgrade upgrade)
+        {
+            if (upgrade == null)
+            {
+                Debug.LogError("[EnvironmentUpgradeManager] Cannot purchase null upgrade");
+                return;
+            }
+
+            // Check if already purchased and active
+            if (_activeUpgrades.Any(u => u.GetType() == upgrade.GetType()))
+            {
+                Debug.LogWarning($"[EnvironmentUpgradeManager] {upgrade.DisplayName} already purchased");
+                return;
+            }
+
+            _activeUpgrades.Add(upgrade);
+            SpawnUpgradePrefab(upgrade);
+
+            Debug.Log($"[EnvironmentUpgradeManager] Purchased: {upgrade.DisplayName}");
+        }
+
+        /// <summary>
+        ///     Injects bonuses from all active upgrades into the ScoreManager.
+        /// </summary>
+        public void InjectBonuses(ScoreManager scoreManager, int healthyPlants, int totalPlants)
+        {
+            if (!scoreManager)
+            {
+                Debug.LogError("[EnvironmentUpgradeManager] Cannot inject bonuses: ScoreManager is null");
+                return;
+            }
+
+            foreach (var upgrade in _activeUpgrades)
+            {
+                var bonus = upgrade.CalculateRoundBonus(healthyPlants, totalPlants);
+                if (bonus == null) continue;
+                scoreManager.bonuses.Add(bonus);
+                Debug.Log($"[EnvironmentUpgradeManager] Added bonus: {bonus.Name} = ${bonus.BonusValue}");
+            }
+        }
+
+        /// <summary>
+        ///     Clears upgrades that last only one round.
+        ///     Called at the end of each round.
+        /// </summary>
+        public void ClearRoundUpgrades()
+        {
+            var roundUpgrades = _activeUpgrades.Where
+                (u => u.Duration == UpgradeDuration.OneRound).ToList();
+
+            foreach (var upgrade in roundUpgrades)
+            {
+                // Destroy spawned prefab
+                if (_spawnedPrefabs.TryGetValue(upgrade, out var prefab) && prefab)
+                {
+                    Destroy(prefab);
+                    _spawnedPrefabs.Remove(upgrade);
+                }
+
+                // Remove from the active list
+                _activeUpgrades.Remove(upgrade);
+            }
+
+            if (roundUpgrades.Count > 0)
+                Debug.Log($"[EnvironmentUpgradeManager] Cleared {roundUpgrades.Count} per-round upgrade(s)");
+        }
+
+        /// <summary>
+        ///     Clears all active upgrades and destroys spawned prefabs.
+        ///     Called at the end of each level.
+        /// </summary>
+        public void ClearUpgrades()
+        {
+            foreach (var kvp in _spawnedPrefabs.Where(kvp => kvp.Value))
+                Destroy(kvp.Value);
+
+            _spawnedPrefabs.Clear();
+            _activeUpgrades.Clear();
+            _nextSpawnPointIndex = 0;
+
+            Debug.Log("[EnvironmentUpgradeManager] Cleared all upgrades");
+        }
+
+        /// <summary>
+        ///     Serializes active upgrades for save system.
+        /// </summary>
+        public List<string> SerializeUpgrades()
+        {
+            return _activeUpgrades.Select(u => u.GetType().FullName).ToList();
+        }
+
+        /// <summary>
+        ///     Restores upgrades from serialized type names (for load system).
+        /// </summary>
+        public void RestoreUpgrades(List<string> typeNames)
+        {
+            if (typeNames == null || typeNames.Count == 0) return;
+
+            ClearUpgrades();
+
+            foreach (var typeName in typeNames)
+                try
+                {
+                    var type = Type.GetType(typeName);
+                    if (type is null)
+                    {
+                        Debug.LogWarning($"[EnvironmentUpgradeManager] Could not find type: {typeName}");
+                        continue;
+                    }
+
+                    if (!typeof(IEnvironmentUpgrade).IsAssignableFrom(type))
+                    {
+                        Debug.LogWarning(
+                            $"[EnvironmentUpgradeManager] Type {typeName} does not implement IEnvironmentUpgrade");
+                        continue;
+                    }
+
+                    var upgrade = (IEnvironmentUpgrade)Activator.CreateInstance(type);
+                    _activeUpgrades.Add(upgrade);
+                    SpawnUpgradePrefab(upgrade);
+
+                    Debug.Log($"[EnvironmentUpgradeManager] Restored: {upgrade.DisplayName}");
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"[EnvironmentUpgradeManager] Failed to restore upgrade {typeName}: {ex.Message}");
+                }
+        }
+
+        private void SpawnUpgradePrefab(IEnvironmentUpgrade upgrade)
+        {
+            if (!upgrade.Prefab)
+            {
+                Debug.LogWarning($"[EnvironmentUpgradeManager] {upgrade.DisplayName} has no prefab to spawn");
+                return;
+            }
+
+            if (upgradeSpawnPoints.Count == 0)
+            {
+                Debug.LogWarning("[EnvironmentUpgradeManager] No spawn points configured");
+                return;
+            }
+
+            if (_nextSpawnPointIndex >= upgradeSpawnPoints.Count)
+            {
+                Debug.LogWarning("[EnvironmentUpgradeManager] All spawn points occupied");
+                return;
+            }
+
+            var spawnPoint = upgradeSpawnPoints[_nextSpawnPointIndex];
+            var instance = Instantiate(upgrade.Prefab, spawnPoint.position, spawnPoint.rotation, spawnPoint);
+            _spawnedPrefabs[upgrade] = instance;
+            _nextSpawnPointIndex++;
+
+            Debug.Log(
+                $"[EnvironmentUpgradeManager] Spawned {upgrade.DisplayName} at spawn point {_nextSpawnPointIndex - 1}");
+        }
+    }
+}

--- a/Card Core/EnvironmentUpgradeManager.cs
+++ b/Card Core/EnvironmentUpgradeManager.cs
@@ -14,30 +14,45 @@ namespace _project.Scripts.Card_Core
         private readonly Dictionary<IEnvironmentUpgrade, GameObject> _spawnedPrefabs = new();
         private int _nextSpawnPointIndex;
 
+        public GameObject beeBoxPrefab;
         public IReadOnlyList<IEnvironmentUpgrade> ActiveUpgrades => _activeUpgrades;
 
+
         /// <summary>
-        ///     Purchases an upgrade, adds it to active upgrades, and spawns its prefab.
+        ///     Checks if an upgrade can be purchased.
         /// </summary>
-        public void PurchaseUpgrade(IEnvironmentUpgrade upgrade)
+        public bool CanPurchaseUpgrade(IEnvironmentUpgrade upgrade)
         {
             if (upgrade == null)
             {
                 Debug.LogError("[EnvironmentUpgradeManager] Cannot purchase null upgrade");
-                return;
+                return false;
             }
 
-            // Check if already purchased and active
             if (_activeUpgrades.Any(u => u.GetType() == upgrade.GetType()))
             {
                 Debug.LogWarning($"[EnvironmentUpgradeManager] {upgrade.DisplayName} already purchased");
-                return;
+                return false;
             }
+
+            if (upgradeSpawnPoints.Count <= 0 || _nextSpawnPointIndex < upgradeSpawnPoints.Count) return true;
+            Debug.LogWarning("[EnvironmentUpgradeManager] Cannot purchase upgrade: all spawn points are occupied");
+            return false;
+        }
+
+        /// <summary>
+        ///     Purchases an upgrade, adds it to active upgrades, and spawns its prefab.
+        /// </summary>
+        public bool PurchaseUpgrade(IEnvironmentUpgrade upgrade)
+        {
+            if (!CanPurchaseUpgrade(upgrade))
+                return false;
 
             _activeUpgrades.Add(upgrade);
             SpawnUpgradePrefab(upgrade);
 
             Debug.Log($"[EnvironmentUpgradeManager] Purchased: {upgrade.DisplayName}");
+            return true;
         }
 
         /// <summary>

--- a/Card Core/ShopManager.cs
+++ b/Card Core/ShopManager.cs
@@ -70,6 +70,7 @@ namespace _project.Scripts.Card_Core
                 new BeeBox(),
             };
 
+            // Add card shop items
             for (var i = 0; i < numberOfCards; i++)
             {
                 var randCard = availableCards[Random.Range(0, availableCards.Count)].Clone();
@@ -79,6 +80,21 @@ namespace _project.Scripts.Card_Core
 
                 var ui = cardObj.GetComponent<ShopObject>();
                 ui.Setup(itemLogic);
+            }
+
+            // Add environment upgrade shop items
+            var upgradeManager = CardGameMaster.Instance.environmentUpgradeManager;
+            if (!upgradeManager) return;
+            {
+                foreach (var upgrade in availableUtilities)
+                {
+                    var upgradeObj = Instantiate(shopItemPrefab, shopItemsParent.transform);
+                    var upgradeItemLogic = new EnvironmentUpgradeShopItem(upgrade, upgradeObj);
+                    currentShopItems.Add(upgradeItemLogic);
+
+                    var ui = upgradeObj.GetComponent<ShopObject>();
+                    ui.Setup(upgradeItemLogic);
+                }
             }
         }
 

--- a/Card Core/ShopObject.cs
+++ b/Card Core/ShopObject.cs
@@ -24,7 +24,7 @@ namespace _project.Scripts.Card_Core
             var image = objectImage ? objectImage : GetComponent<Image>();
             if (image is null) return;
 
-            var cardMaterial = ShopItem?.Card?.Material;
+            var cardMaterial = ShopItem?.DisplayMaterial;
             if (cardMaterial is null)
             {
                 image.material = null;

--- a/Card Core/TurnController.cs
+++ b/Card Core/TurnController.cs
@@ -712,6 +712,11 @@ namespace _project.Scripts.Card_Core
                 Debug.Log($"[TurnController] No bonus: {plantsHealthy}/{plantControllers.Length} plants healthy");
             }
 
+            // Inject environment upgrade bonuses
+            var upgradeManager = CardGameMaster.Instance.environmentUpgradeManager;
+            if (upgradeManager && _scoreManager)
+                upgradeManager.InjectBonuses(_scoreManager, plantsHealthy, plantControllers.Length);
+
             var scoreBeforeRound = ScoreManager.GetMoneys();
             var score = _scoreManager.CalculateScore();
             if (_scoreManager) _scoreManager.treatmentCost = 0;
@@ -736,6 +741,9 @@ namespace _project.Scripts.Card_Core
             {
                 Debug.LogWarning($"[Analytics] RecordRoundEnd error: {ex.Message}");
             }
+
+            // Clear per-round upgrades after bonuses have been applied and score calculated
+            if (upgradeManager) upgradeManager.ClearRoundUpgrades();
 
             // Handle different game modes
             if (currentGameMode == GameMode.Campaign && !IsActiveTutorialStep)
@@ -793,6 +801,11 @@ namespace _project.Scripts.Card_Core
             UpdateMoneyGoal();
             _deckManager.ResetRedrawCount();
             DeckManager.GeneratePlantPrices();
+
+            // Clear environment upgrades at end of level
+            var upgradeManager = CardGameMaster.Instance.environmentUpgradeManager;
+            if (upgradeManager) upgradeManager.ClearUpgrades();
+
             if (!shopQueued) return;
             CardGameMaster.Instance.shopManager.OpenShop();
             shopQueued = false;

--- a/Classes/ShopClasses.cs
+++ b/Classes/ShopClasses.cs
@@ -15,17 +15,57 @@ namespace _project.Scripts.Classes
         public void Purchase();
     }
 
+    public enum UpgradeDuration
+    {
+        OneRound,    // Cleared at the end of round
+        OneLevel     // Cleared at the end of level (all 5 rounds)
+    }
+
     public interface IEnvironmentUpgrade : IShopItem
     {
-       public GameObject GameObject { get; }
-       public Material IconMaterial { get; }
-       [CanBeNull] public IBonus  Bonus { get; }
+        public GameObject Prefab { get; }
+        public Material IconMaterial { get; }
+        public UpgradeDuration Duration { get; }
+
+        [CanBeNull]
+        IBonus CalculateRoundBonus(int healthyPlantCount, int totalPlantCount);
+    }
+
+    /// <summary>
+    ///     Shop item implementation for environment upgrades.
+    ///     Wraps IEnvironmentUpgrade to be displayed and purchased in the shop.
+    /// </summary>
+    public class EnvironmentUpgradeShopItem : IShopItem
+    {
+        private readonly GameObject _gameObject;
+        private readonly IEnvironmentUpgrade _upgrade;
+
+        public EnvironmentUpgradeShopItem(IEnvironmentUpgrade upgrade, GameObject gameObject)
+        {
+            _upgrade = upgrade;
+            _gameObject = gameObject;
+        }
+
+        // Environment upgrades are not cards
+        public ICard Card => null;
+
+        public Material DisplayMaterial => _upgrade.IconMaterial;
+
+        public string DisplayName => _upgrade.DisplayName;
+
+        public int Cost => _upgrade.Cost;
+
+        public void Purchase()
+        {
+            _upgrade.Purchase();
+            CardGameMaster.Instance.shopManager.RemoveShopItem(_gameObject);
+        }
     }
     
     public class CardShopItem : IShopItem
     {
         public ICard Card { get; }
-        public Material DisplayMaterial => null;
+        public Material DisplayMaterial => Card.Material;
         public string DisplayName => Card.Name;
         public int Cost => Math.Abs(Card.Value ?? 0);
 
@@ -50,20 +90,39 @@ namespace _project.Scripts.Classes
     public class BeeBox : IEnvironmentUpgrade
     {
         public ICard Card => null;
-        public Material DisplayMaterial => null;
-        public GameObject GameObject => null;
-        public Material IconMaterial => null;
-        public IBonus Bonus => new()
-        {
-            Name =  "BeeBox",
-            BonusValue = 2
-        };
-        
+        public Material DisplayMaterial => IconMaterial;
+        public GameObject Prefab => Resources.Load<GameObject>($"Prefabs/Upgrades/BeeBox");
+        public Material IconMaterial => Resources.Load<Material>($"Materials/Upgrades/BeeBoxIcon");
+
         public string DisplayName => "Bee Box";
-        public int Cost => 10;
+        public string Description => "Pollination boost: +$2 per healthy plant this round";
+        public int Cost => 15;
+        public static int BonusPerPlant => 2;
+        public UpgradeDuration Duration => UpgradeDuration.OneRound;
+
+        public IBonus CalculateRoundBonus(int healthyPlantCount, int totalPlantCount)
+        {
+            var value = healthyPlantCount * BonusPerPlant;
+            return value > 0 ? new IBonus { Name = "Bee Box", BonusValue = value } : null;
+        }
+
         public void Purchase()
         {
-            throw new NotImplementedException();
+            if (!CardGameMaster.Instance)
+            {
+                Debug.LogError("[BeeBox] Purchase failed: CardGameMaster not initialized!");
+                return;
+            }
+
+            var manager = CardGameMaster.Instance.environmentUpgradeManager;
+            if (!manager)
+            {
+                Debug.LogError("[BeeBox] Purchase failed: EnvironmentUpgradeManager not found!");
+                return;
+            }
+
+            manager.PurchaseUpgrade(this);
+            ScoreManager.SubtractMoneys(Cost);
         }
     }
 }

--- a/Classes/ShopClasses.cs
+++ b/Classes/ShopClasses.cs
@@ -57,6 +57,22 @@ namespace _project.Scripts.Classes
 
         public void Purchase()
         {
+            if (!CardGameMaster.Instance)
+            {
+                Debug.LogError("[EnvironmentUpgradeShopItem] Purchase failed: CardGameMaster not initialized!");
+                return;
+            }
+
+            var manager = CardGameMaster.Instance.environmentUpgradeManager;
+            if (!manager)
+            {
+                Debug.LogError("[EnvironmentUpgradeShopItem] Purchase failed: EnvironmentUpgradeManager not found!");
+                return;
+            }
+
+            if (!manager.CanPurchaseUpgrade(_upgrade))
+                return;
+
             _upgrade.Purchase();
             CardGameMaster.Instance.shopManager.RemoveShopItem(_gameObject);
         }
@@ -91,7 +107,7 @@ namespace _project.Scripts.Classes
     {
         public ICard Card => null;
         public Material DisplayMaterial => IconMaterial;
-        public GameObject Prefab => Resources.Load<GameObject>($"Prefabs/Upgrades/BeeBox");
+        public GameObject Prefab => CardGameMaster.Instance.environmentUpgradeManager.beeBoxPrefab;
         public Material IconMaterial => Resources.Load<Material>($"Materials/Upgrades/BeeBoxIcon");
 
         public string DisplayName => "Bee Box";
@@ -121,7 +137,9 @@ namespace _project.Scripts.Classes
                 return;
             }
 
-            manager.PurchaseUpgrade(this);
+            if (!manager.PurchaseUpgrade(this))
+                return;
+
             ScoreManager.SubtractMoneys(Cost);
         }
     }

--- a/GameState/GameStateData.cs
+++ b/GameState/GameStateData.cs
@@ -11,6 +11,7 @@ namespace _project.Scripts.GameState
         public DeckData deckData;
         public List<PlantData> plants;
         public RetainedCardData retainedCard;
+        public EnvironmentUpgradeData environmentUpgrades;
     }
 
     [Serializable]
@@ -107,5 +108,11 @@ namespace _project.Scripts.GameState
         public CardData card;
         public bool hasPaidForCard;
         public bool isCardLocked;
+    }
+
+    [Serializable]
+    public class EnvironmentUpgradeData
+    {
+        public List<string> activeUpgradeTypeNames;
     }
 }

--- a/GameState/GameStateManager.cs
+++ b/GameState/GameStateManager.cs
@@ -71,6 +71,16 @@ namespace _project.Scripts.GameState
             else
                 data.retainedCard = null; // No retained card to save
 
+            // Environment Upgrades
+            var upgradeManager = CardGameMaster.Instance?.environmentUpgradeManager;
+            if (upgradeManager != null)
+            {
+                data.environmentUpgrades = new EnvironmentUpgradeData
+                {
+                    activeUpgradeTypeNames = upgradeManager.SerializeUpgrades()
+                };
+            }
+
             // Save to PlayerPrefs
             var json = JsonUtility.ToJson(data);
             PlayerPrefs.SetString("GameState", json);
@@ -229,6 +239,13 @@ namespace _project.Scripts.GameState
             {
                 // No retained card in save data, ensure the slot is clear
                 retained.ClearHeldCard();
+            }
+
+            // Restore Environment Upgrades
+            var upgradeManager = CardGameMaster.Instance?.environmentUpgradeManager;
+            if (upgradeManager != null && data.environmentUpgrades?.activeUpgradeTypeNames != null)
+            {
+                upgradeManager.RestoreUpgrades(data.environmentUpgrades.activeUpgradeTypeNames);
             }
         }
 

--- a/PlayModeTest/EnvironmentUpgradeTests.cs
+++ b/PlayModeTest/EnvironmentUpgradeTests.cs
@@ -1,0 +1,277 @@
+using System.Collections;
+using System.Collections.Generic;
+using _project.Scripts.Card_Core;
+using _project.Scripts.Classes;
+using _project.Scripts.GameState;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace _project.Scripts.PlayModeTest
+{
+    public class EnvironmentUpgradeTests
+    {
+        private GameObject _testGameObject;
+        private EnvironmentUpgradeManager _manager;
+        private ScoreManager _scoreManager;
+
+        [SetUp]
+        public void Setup()
+        {
+            _testGameObject = new GameObject("TestUpgradeManager");
+            _manager = _testGameObject.AddComponent<EnvironmentUpgradeManager>();
+            _scoreManager = _testGameObject.AddComponent<ScoreManager>();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            if (_testGameObject != null)
+                Object.DestroyImmediate(_testGameObject);
+        }
+
+        [Test]
+        public void BeeBox_CalculatesCorrectBonus()
+        {
+            // Arrange
+            var beeBox = new BeeBox();
+
+            // Act - 3 healthy plants
+            var bonus = beeBox.CalculateRoundBonus(3, 5);
+
+            // Assert
+            Assert.IsNotNull(bonus, "Bonus should not be null");
+            Assert.AreEqual("Bee Box", bonus.Name);
+            Assert.AreEqual(6, bonus.BonusValue, "3 healthy plants * $2 = $6");
+        }
+
+        [Test]
+        public void BeeBox_ReturnsNullBonus_WhenNoHealthyPlants()
+        {
+            // Arrange
+            var beeBox = new BeeBox();
+
+            // Act
+            var bonus = beeBox.CalculateRoundBonus(0, 5);
+
+            // Assert
+            Assert.IsNull(bonus, "Bonus should be null when no healthy plants");
+        }
+
+        [Test]
+        public void BeeBox_HasCorrectProperties()
+        {
+            // Arrange
+            var beeBox = new BeeBox();
+
+            // Assert
+            Assert.AreEqual("Bee Box", beeBox.DisplayName);
+            Assert.AreEqual(15, beeBox.Cost);
+            Assert.AreEqual(2, BeeBox.BonusPerPlant);
+            Assert.AreEqual(UpgradeDuration.OneRound, beeBox.Duration);
+            Assert.IsNull(beeBox.Card, "Environment upgrades are not cards");
+        }
+
+        [Test]
+        public void PurchaseUpgrade_AddsToActiveList()
+        {
+            // Arrange
+            var beeBox = new BeeBox();
+
+            // Act
+            _manager.PurchaseUpgrade(beeBox);
+
+            // Assert
+            Assert.AreEqual(1, _manager.ActiveUpgrades.Count);
+            Assert.AreSame(beeBox, _manager.ActiveUpgrades[0]);
+        }
+
+        [Test]
+        public void PurchaseUpgrade_PreventsDuplicates()
+        {
+            // Arrange
+            var beeBox1 = new BeeBox();
+            var beeBox2 = new BeeBox();
+
+            // Act
+            _manager.PurchaseUpgrade(beeBox1);
+            _manager.PurchaseUpgrade(beeBox2); // Should be rejected
+
+            // Assert
+            Assert.AreEqual(1, _manager.ActiveUpgrades.Count, "Should not add duplicate upgrade type");
+        }
+
+        [Test]
+        public void InjectBonuses_AddsBonusesToScoreManager()
+        {
+            // Arrange
+            var beeBox = new BeeBox();
+            _manager.PurchaseUpgrade(beeBox);
+
+            // Act
+            _manager.InjectBonuses(_scoreManager, 4, 5);
+
+            // Assert
+            Assert.AreEqual(1, _scoreManager.bonuses.Count);
+            Assert.AreEqual("Bee Box", _scoreManager.bonuses[0].Name);
+            Assert.AreEqual(8, _scoreManager.bonuses[0].BonusValue); // 4 healthy * $2
+        }
+
+        [Test]
+        public void InjectBonuses_SkipsNullBonuses()
+        {
+            // Arrange
+            var beeBox = new BeeBox();
+            _manager.PurchaseUpgrade(beeBox);
+
+            // Act - No healthy plants
+            _manager.InjectBonuses(_scoreManager, 0, 5);
+
+            // Assert
+            Assert.AreEqual(0, _scoreManager.bonuses.Count, "No bonus should be added for 0 healthy plants");
+        }
+
+        [Test]
+        public void ClearRoundUpgrades_RemovesOnlyOneRoundUpgrades()
+        {
+            // Arrange
+            var beeBox = new BeeBox(); // OneRound duration
+            _manager.PurchaseUpgrade(beeBox);
+
+            // Act
+            _manager.ClearRoundUpgrades();
+
+            // Assert
+            Assert.AreEqual(0, _manager.ActiveUpgrades.Count, "OneRound upgrades should be cleared");
+        }
+
+        [Test]
+        public void ClearUpgrades_RemovesAllUpgrades()
+        {
+            // Arrange
+            var beeBox = new BeeBox();
+            _manager.PurchaseUpgrade(beeBox);
+
+            // Act
+            _manager.ClearUpgrades();
+
+            // Assert
+            Assert.AreEqual(0, _manager.ActiveUpgrades.Count);
+        }
+
+        [Test]
+        public void SerializeUpgrades_ReturnsTypeNames()
+        {
+            // Arrange
+            var beeBox = new BeeBox();
+            _manager.PurchaseUpgrade(beeBox);
+
+            // Act
+            var serialized = _manager.SerializeUpgrades();
+
+            // Assert
+            Assert.AreEqual(1, serialized.Count);
+            Assert.AreEqual(typeof(BeeBox).FullName, serialized[0]);
+        }
+
+        [Test]
+        public void RestoreUpgrades_RecreatesUpgrades()
+        {
+            // Arrange
+            var typeNames = new List<string> { typeof(BeeBox).FullName };
+
+            // Act
+            _manager.RestoreUpgrades(typeNames);
+
+            // Assert
+            Assert.AreEqual(1, _manager.ActiveUpgrades.Count);
+            Assert.IsInstanceOf<BeeBox>(_manager.ActiveUpgrades[0]);
+        }
+
+        [Test]
+        public void RestoreUpgrades_HandlesEmptyList()
+        {
+            // Act
+            _manager.RestoreUpgrades(new List<string>());
+
+            // Assert
+            Assert.AreEqual(0, _manager.ActiveUpgrades.Count);
+        }
+
+        [Test]
+        public void RestoreUpgrades_HandlesInvalidTypeName()
+        {
+            // Arrange
+            var typeNames = new List<string> { "Invalid.Type.Name" };
+
+            // Act & Assert - Should not throw
+            Assert.DoesNotThrow(() => _manager.RestoreUpgrades(typeNames));
+            Assert.AreEqual(0, _manager.ActiveUpgrades.Count);
+        }
+
+        [Test]
+        public void EnvironmentUpgradeData_SerializesCorrectly()
+        {
+            // Arrange
+            var data = new EnvironmentUpgradeData
+            {
+                activeUpgradeTypeNames = new List<string> { typeof(BeeBox).FullName }
+            };
+
+            // Act
+            var json = JsonUtility.ToJson(data);
+            var deserialized = JsonUtility.FromJson<EnvironmentUpgradeData>(json);
+
+            // Assert
+            Assert.IsNotNull(deserialized);
+            Assert.AreEqual(1, deserialized.activeUpgradeTypeNames.Count);
+            Assert.AreEqual(typeof(BeeBox).FullName, deserialized.activeUpgradeTypeNames[0]);
+        }
+
+        [UnityTest]
+        public IEnumerator FullWorkflow_PurchaseAndCalculateBonus()
+        {
+            // Arrange
+            var beeBox = new BeeBox();
+
+            // Act - Purchase
+            _manager.PurchaseUpgrade(beeBox);
+            yield return null;
+
+            // Act - Calculate bonus for 5 healthy plants
+            _manager.InjectBonuses(_scoreManager, 5, 6);
+
+            // Assert
+            Assert.AreEqual(1, _scoreManager.bonuses.Count);
+            Assert.AreEqual(10, _scoreManager.bonuses[0].BonusValue); // 5 * $2
+        }
+
+        [UnityTest]
+        public IEnumerator FullWorkflow_PersistenceCycle()
+        {
+            // Arrange
+            var beeBox = new BeeBox();
+            _manager.PurchaseUpgrade(beeBox);
+            yield return null;
+
+            // Act - Serialize
+            var serialized = _manager.SerializeUpgrades();
+
+            // Act - Clear and restore
+            _manager.ClearUpgrades();
+            Assert.AreEqual(0, _manager.ActiveUpgrades.Count, "Should be cleared");
+            yield return null;
+
+            _manager.RestoreUpgrades(serialized);
+
+            // Assert
+            Assert.AreEqual(1, _manager.ActiveUpgrades.Count);
+            Assert.IsInstanceOf<BeeBox>(_manager.ActiveUpgrades[0]);
+
+            // Verify functionality after restore
+            _manager.InjectBonuses(_scoreManager, 3, 5);
+            Assert.AreEqual(1, _scoreManager.bonuses.Count);
+            Assert.AreEqual(6, _scoreManager.bonuses[0].BonusValue);
+        }
+    }
+}


### PR DESCRIPTION
## Summary                                                                                                                                  
                                                                                                                                                                                                                                                                                                                       
   - Introduces  — a new MonoBehaviour that manages purchasable environment upgrades (starting with the BeeBox) including spawn point assignment, activation/deactivation lifecycle, and prefab instantiation                                                                             
   - Integrates environment upgrades into the gameplay loop:  holds a reference to the manager,  routes purchase of  shop items to it, and  applies upgrade effects at the start of each turn
   - Adds serialization and restoration of active environment upgrades in / so upgrades persist across save/load cycles
   - Extends  with  and related types to represent upgrades in the shop
   - Covers the system with  including purchase validation, duplicate prevention, and save/restore round-trips